### PR TITLE
Config schema proposal

### DIFF
--- a/GDWeave/Loader/ModManifest.cs
+++ b/GDWeave/Loader/ModManifest.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices.JavaScript;
-
-namespace GDWeave;
+﻿namespace GDWeave;
 
 internal class ModManifest {
     public required string Id { get; set; }

--- a/GDWeave/Loader/ModManifest.cs
+++ b/GDWeave/Loader/ModManifest.cs
@@ -29,12 +29,8 @@ internal class ModManifest {
         public float? Maximum { get; set; }
         public float? MultipleOf { get; set; }
         public Dictionary<string, ModConfigProperty>? Properties { get; set; }
-        public ArrayItems? Items { get; set; }
+        public ModConfigProperty? Items { get; set; }
         public int? MinItems { get; set; }
         public int? MaxItems { get; set; }
-    }
-
-    internal class ArrayItems {
-        public string? Type { get; set; }
     }
 }

--- a/GDWeave/Loader/ModManifest.cs
+++ b/GDWeave/Loader/ModManifest.cs
@@ -1,4 +1,6 @@
-﻿namespace GDWeave;
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace GDWeave;
 
 internal class ModManifest {
     public required string Id { get; set; }
@@ -6,6 +8,7 @@ internal class ModManifest {
     public string? PackPath { get; set; }
     public List<string> Dependencies { get; set; } = new();
     public ModMetadata? Metadata { get; set; }
+    public Dictionary<string, ModConfigProperty>? ConfigSchema { get; set; }
 
     internal class ModMetadata {
         public string? Name { get; set; }
@@ -13,5 +16,27 @@ internal class ModManifest {
         public string? Version { get; set; }
         public string? Description { get; set; }
         public string? Homepage { get; set; }
+    }
+
+    internal class ModConfigProperty {
+        public string? Title { get; set; }
+        public string? Description { get; set; }
+        public string? Type { get; set; }
+        public int? MinLength { get; set; }
+        public int? MaxLength { get; set; }
+        public string? Pattern { get; set; }
+        public List<object>? Enum { get; set; }
+        public List<string>? SuggestedEnum { get; set; }
+        public float? Minimum { get; set; }
+        public float? Maximum { get; set; }
+        public float? MultipleOf { get; set; }
+        public Dictionary<string, ModConfigProperty>? Properties { get; set; }
+        public ArrayItems? Items { get; set; }
+        public int? MinItems { get; set; }
+        public int? MaxItems { get; set; }
+    }
+
+    internal class ArrayItems {
+        public string? Type { get; set; }
     }
 }


### PR DESCRIPTION
my proposal for a config schema field in the mod manifest based on the layout of json schema. sorry for the c# side of things being lacking, im aware it could be better

properties will use the following types and the additional data associated with them:

- `string`:
  - `MinLength`
  - `MaxLength`
  - `Pattern`: a regex pattern for use in C#. since godot's regex is based on PCRE, mod devs should define patterns separately in their gdscript code when required. hesitant with this one because of the catch
- `int`/`float`:
  - `Minimum`
  - `Maximum`
  - `MultipleOf`
- `string`/`int`/`float`:
  - `Enum`: a list of acceptable values
  - `SuggestedEnum`: a list of suggested values for hints/autocomplete in UIs, but any value is accepted
- `object`:
  - `Properties`
- `array`:
  - `Items`
  - `MinItems`
  - `MaxItems`
- `bool`

would love discussion ty ૮ ˶′ ཅ ‵˶ ა