### PR TITLE
Fix a few issues with ScriptTokenizer.cs

### DIFF
--- a/GDWeave/Script/ScriptTokenizer.cs
+++ b/GDWeave/Script/ScriptTokenizer.cs
@@ -366,10 +366,10 @@ public static class ScriptTokenizer {
                     yield return ClearBuilder();
                     var start = i;
                     i++;
-                    for (; i < text.Length && text[i] == ' '; i++) ;
+                    for (; i < text.Length && text[i] == '\t'; i++) ;
                     i--;
                     yield return "\n";
-                    yield return $"{(i - start) / 4}";
+                    yield return $"{i - start}";
                     continue;
                 }
             }

--- a/GDWeave/Script/ScriptTokenizer.cs
+++ b/GDWeave/Script/ScriptTokenizer.cs
@@ -66,7 +66,7 @@ public static class ScriptTokenizer {
         {"[", TokenType.BracketOpen},
         {"]", TokenType.BracketClose},
         {"{", TokenType.CurlyBracketOpen},
-        {"}", TokenType.CurlyBracketOpen},
+        {"}", TokenType.CurlyBracketClose},
 
         {"(", TokenType.ParenthesisOpen},
         {")", TokenType.ParenthesisClose},


### PR DESCRIPTION
```
{"{", TokenType.CurlyBracketOpen},
{"}", TokenType.CurlyBracketOpen},
```
^ This don't look right!

Getting errors when using the script tokenizer about unexpected "{"
![image](https://github.com/user-attachments/assets/5b993947-0ba8-4da3-b6af-3e22d449a0ba)
Turns out it never places a }, because it puts a { !