### PR TITLE
Fix: missing string quotations in codegen output

### DIFF
--- a/GDWeave.Dumper/CodeGenerator.cs
+++ b/GDWeave.Dumper/CodeGenerator.cs
@@ -1,4 +1,5 @@
 using GDWeave.Godot;
+using GDWeave.Godot.Variants;
 
 public class CodeGenerator(List<Token> tokens, List<string> identifiers) {
     public void Generate(StreamWriter writer) {
@@ -30,7 +31,11 @@ public class CodeGenerator(List<Token> tokens, List<string> identifiers) {
             case TokenType.Identifier:
                 return $"{identifiers[data]}";
             case TokenType.Constant:
-                var constantToken = (ConstantToken) token;
+                var constantToken = (ConstantToken)token;
+                if (
+                    constantToken.Value is StringVariant stringVariant
+                    && stringVariant.GetValue() is string str
+                ) { return $"\"{str}\""; }
                 return constantToken.Value.GetValue().ToString() ?? "<Failed to convert to string>";
             case TokenType.Newline:
                 tabs = token.AssociatedData ?? 0;


### PR DESCRIPTION
_Codegen currently outputs all constants the same without regard for whether the value should be "unpacked" into a string literal_, with quotation marks. This results in pretty weird looking code generation, which is -sure- OK for an approximation, at best... But also totally unreadable at worst:
<img width="1097" height="1037" alt="Not too hard" src="https://github.com/user-attachments/assets/12d426a5-9edf-4c18-af8f-18ecc91b40c9" />

<img width="1064" height="817" alt="Really bad" src="https://github.com/user-attachments/assets/83a6e871-222a-42f3-a6f0-b9047a2323a3" />


This change will tweak the `Constant` token case to add quotes when generating with `StringVariant` tokens. 
